### PR TITLE
Fix docker builds for agents and observer

### DIFF
--- a/acp-emergent/acp.proto
+++ b/acp-emergent/acp.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package acp.v1;
+
+// Generic envelope (MCP/ACP-style) carrying JSON payloads
+message AgentMessage {
+  string agent_id = 1;            // Source agent name
+  string content_type = 2;        // e.g. "application/json"
+  bytes payload = 3;              // raw JSON or text
+}
+
+// Simple ping RPC for stub validation
+service ACPService {
+  rpc Ping (AgentMessage) returns (AgentMessage);
+}

--- a/acp-emergent/docker-compose.yml
+++ b/acp-emergent/docker-compose.yml
@@ -6,6 +6,15 @@ services:
       dockerfile: docker/server.Dockerfile
     ports:
       - "50051:50051"
+    networks:
+      - acp-network
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    networks:
+      - acp-network
 
   synthesizer:
     build:
@@ -14,9 +23,12 @@ services:
     environment:
       AGENT_ROLE: synthesizer
       ACP_ADDR: acp-server:50051
-      OLLAMA_HOST: host.docker.internal:11434
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      OLLAMA_HOST: ollama:11434
+    networks:
+      - acp-network
+    depends_on:
+      - ollama
+      - acp-server
 
   sentinel:
     build:
@@ -25,9 +37,12 @@ services:
     environment:
       AGENT_ROLE: sentinel
       ACP_ADDR: acp-server:50051
-      OLLAMA_HOST: host.docker.internal:11434
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      OLLAMA_HOST: ollama:11434
+    networks:
+      - acp-network
+    depends_on:
+      - ollama
+      - acp-server
 
   expert:
     build:
@@ -36,15 +51,26 @@ services:
     environment:
       AGENT_ROLE: expert
       ACP_ADDR: acp-server:50051
-      OLLAMA_HOST: host.docker.internal:11434
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      OLLAMA_HOST: ollama:11434
+    networks:
+      - acp-network
+    depends_on:
+      - ollama
+      - acp-server
 
   observer:
     build:
-      context: ./observer
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: observer/Dockerfile
     volumes:
       - ./logs:/logs
     environment:
       ACP_ADDR: acp-server:50051
+    networks:
+      - acp-network
+    depends_on:
+      - acp-server
+
+networks:
+  acp-network:
+    driver: bridge

--- a/acp-emergent/docker/agent.Dockerfile
+++ b/acp-emergent/docker/agent.Dockerfile
@@ -1,6 +1,19 @@
 FROM python:3.11-slim
 WORKDIR /app
+
+# Copy proto file and generate protobuf code
+COPY acp.proto .
+RUN pip install --no-cache-dir grpcio-tools
+RUN python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. acp.proto
+
+# Copy application files
 COPY agents/ ./agents/
+COPY genesis_protocol.py .
+
 WORKDIR /app/agents
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install additional dependencies for Ollama client
+RUN pip install --no-cache-dir requests urllib3
+
 CMD ["python", "run_agent.py"]

--- a/acp-emergent/observer/Dockerfile
+++ b/acp-emergent/observer/Dockerfile
@@ -1,5 +1,16 @@
 FROM python:3.11-slim
 WORKDIR /app
+
+# Copy proto file and generate protobuf code
+COPY acp.proto .
+RUN pip install --no-cache-dir grpcio grpcio-tools protobuf
+RUN python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. acp.proto
+
+# Copy application files
 COPY observer/observer.py .
-RUN pip install grpcio
+COPY observer/requirements.txt .
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
 CMD ["python", "observer.py"]

--- a/acp-emergent/observer/requirements.txt
+++ b/acp-emergent/observer/requirements.txt
@@ -2,5 +2,3 @@ grpcio>=1.54.0
 grpcio-tools>=1.54.0
 protobuf>=4.22.3
 pyyaml>=6.0
-requests>=2.31.0
-urllib3>=2.0.0


### PR DESCRIPTION
## Summary
- copy `acp.proto` into emergent scaffolding so Docker builds can find it
- extend observer Dockerfile to install dependencies and compile proto
- add requirements for observer
- rebuild agent image to compile proto and install requests libs
- update agent requirements versions
- overhaul docker-compose to add ollama service and networking

## Testing
- `python test_setup.py`

------
https://chatgpt.com/codex/tasks/task_b_68451555f6d0832dbffdb8d546012311