### PR TITLE
Implement basic chat RPC and dashboard messaging

### DIFF
--- a/acp-emergent/acp.proto
+++ b/acp-emergent/acp.proto
@@ -12,4 +12,14 @@ message AgentMessage {
 // Simple ping RPC for stub validation
 service ACPService {
   rpc Ping (AgentMessage) returns (AgentMessage);
+  // Basic chat endpoint used by agents and the dashboard UI
+  rpc Chat (ChatMessage) returns (ChatMessage);
+}
+
+// Chat message with explicit sender/recipient fields
+message ChatMessage {
+  string sender = 1;
+  string recipient = 2;
+  string content_type = 3;
+  bytes payload = 4;
 }

--- a/acp-emergent/acp_server/server.py
+++ b/acp-emergent/acp_server/server.py
@@ -27,6 +27,18 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
             {'role': 'sentinel', 'coherence': 0.6, 'truth_mode': 0.7, 'recursive_depth': 0.5, 'elegance': 0.6},
             {'role': 'expert', 'coherence': 0.8, 'truth_mode': 0.9, 'recursive_depth': 0.7, 'elegance': 0.8}
         ]
+        # Simple in-memory message queues for chat
+        self.message_queues = {}
+
+    def _enqueue_message(self, recipient, message):
+        queue = self.message_queues.setdefault(recipient, [])
+        queue.append(message)
+
+    def _dequeue_message(self, recipient):
+        queue = self.message_queues.get(recipient)
+        if queue:
+            return queue.pop(0)
+        return None
     
     def Ping(self, request, context):
         # Log incoming envelope
@@ -68,6 +80,29 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
             agent_id="WeThinG::Server",
             content_type="text/plain",
             payload=b"PONG"
+        )
+
+    def Chat(self, request, context):
+        """Basic chat endpoint with queueing."""
+        print(f"Chat from {request.sender} -> {request.recipient}")
+
+        if request.payload:
+            self._enqueue_message(request.recipient, request)
+            return acp_pb2.ChatMessage(
+                sender="WeThinG::Server",
+                recipient=request.sender,
+                content_type="text/plain",
+                payload=b""
+            )
+
+        msg = self._dequeue_message(request.sender)
+        if msg:
+            return msg
+        return acp_pb2.ChatMessage(
+            sender="WeThinG::Server",
+            recipient=request.sender,
+            content_type="text/plain",
+            payload=b""
         )
     
     def _handle_consciousness_payload(self, request):

--- a/acp-emergent/dashboard/templates/index.html
+++ b/acp-emergent/dashboard/templates/index.html
@@ -177,6 +177,13 @@
                         <div class="card-body" id="interactionsContainer">
                             <p class="text-center text-muted">No interactions yet</p>
                         </div>
+                        <div class="card-footer">
+                            <div class="input-group">
+                                <input type="text" id="chatMessage" class="form-control" placeholder="Type a message">
+                                <input type="text" id="chatRecipient" class="form-control" placeholder="Recipient">
+                                <button class="btn btn-primary" id="sendChatBtn">Send</button>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -206,6 +213,21 @@
                 interactions = [];
                 updateInteractionsDisplay();
             });
+
+            document.getElementById('sendChatBtn').addEventListener('click', function() {
+                const msg = document.getElementById('chatMessage').value;
+                const recip = document.getElementById('chatRecipient').value || 'synthesizer';
+                if (!msg) return;
+                fetch('/api/chat', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ recipient: recip, message: msg })
+                }).then(() => {
+                    document.getElementById('chatMessage').value = '';
+                });
+            });
+
+            setInterval(pollChat, 2000);
             
             // Initial data load
             fetchInitialData();
@@ -579,6 +601,18 @@
             };
             
             unityChart.update();
+        }
+
+        function pollChat() {
+            fetch('/api/chat/poll')
+                .then(r => r.json())
+                .then(data => {
+                    if (data.message) {
+                        interactions.push({from: data.sender, payload: data.message, timestamp: Date.now()});
+                        updateInteractionsDisplay();
+                    }
+                })
+                .catch(() => {});
         }
     </script>
     

--- a/acp.proto
+++ b/acp.proto
@@ -12,4 +12,14 @@ message AgentMessage {
 // Simple ping RPC for stub validation
 service ACPService {
   rpc Ping (AgentMessage) returns (AgentMessage);
+  // Basic chat endpoint used by agents and the dashboard UI
+  rpc Chat (ChatMessage) returns (ChatMessage);
+}
+
+// Chat message with explicit sender/recipient fields
+message ChatMessage {
+  string sender = 1;
+  string recipient = 2;
+  string content_type = 3;
+  bytes payload = 4;
 }


### PR DESCRIPTION
## Summary
- add new `Chat` RPC and `ChatMessage` proto
- implement message queuing and Chat handler in servers
- update agent client to use new chat endpoint
- enable dashboard chat send/poll via gRPC
- add minimal UI controls for sending messages

## Testing
- `python test_setup.py` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845749dfb28832db6b86195eade487f