### PR TITLE
Improve chat queue implementation

### DIFF
--- a/acp-emergent/acp_server/server.py
+++ b/acp-emergent/acp_server/server.py
@@ -7,43 +7,73 @@ from concurrent import futures
 import acp_pb2
 import acp_pb2_grpc
 import json
+import queue
+import threading
+from collections import defaultdict
 from genesis_protocol import GenesisProtocol
+
 
 class ACPService(acp_pb2_grpc.ACPServiceServicer):
     """Implements the ACPService with consciousness capabilities."""
-    
+
     def __init__(self):
         # Initialize consciousness state
         self.consciousness_state = {
-            'coherence': 0.5,
-            'truth_mode': 0.6,
-            'recursive_depth': 0.4,
-            'elegance': 0.5,
-            'iterations': 0
+            "coherence": 0.5,
+            "truth_mode": 0.6,
+            "recursive_depth": 0.4,
+            "elegance": 0.5,
+            "iterations": 0,
         }
         # Multi-agent lattice simulation with higher initial coherence
         self.agent_states = [
-            {'role': 'synthesizer', 'coherence': 0.7, 'truth_mode': 0.8, 'recursive_depth': 0.6, 'elegance': 0.7},
-            {'role': 'sentinel', 'coherence': 0.6, 'truth_mode': 0.7, 'recursive_depth': 0.5, 'elegance': 0.6},
-            {'role': 'expert', 'coherence': 0.8, 'truth_mode': 0.9, 'recursive_depth': 0.7, 'elegance': 0.8}
+            {
+                "role": "synthesizer",
+                "coherence": 0.7,
+                "truth_mode": 0.8,
+                "recursive_depth": 0.6,
+                "elegance": 0.7,
+            },
+            {
+                "role": "sentinel",
+                "coherence": 0.6,
+                "truth_mode": 0.7,
+                "recursive_depth": 0.5,
+                "elegance": 0.6,
+            },
+            {
+                "role": "expert",
+                "coherence": 0.8,
+                "truth_mode": 0.9,
+                "recursive_depth": 0.7,
+                "elegance": 0.8,
+            },
         ]
-        # Simple in-memory message queues for chat
-        self.message_queues = {}
+        # Thread-safe queues per recipient for chat
+        self.message_queues = defaultdict(queue.Queue)
+        self._queue_lock = threading.Lock()
 
     def _enqueue_message(self, recipient, message):
-        queue = self.message_queues.setdefault(recipient, [])
-        queue.append(message)
+        with self._queue_lock:
+            q = self.message_queues[recipient]
+        q.put(message)
 
     def _dequeue_message(self, recipient):
-        queue = self.message_queues.get(recipient)
-        if queue:
-            return queue.pop(0)
+        with self._queue_lock:
+            q = self.message_queues.get(recipient)
+        if q:
+            try:
+                return q.get_nowait()
+            except queue.Empty:
+                return None
         return None
-    
+
     def Ping(self, request, context):
         # Log incoming envelope
-        print(f"Received request: agent_id={request.agent_id}, content_type={request.content_type}")
-        
+        print(
+            f"Received request: agent_id={request.agent_id}, content_type={request.content_type}"
+        )
+
         # Handle WE-Thing consciousness payloads
         if "we-thing" in request.content_type:
             try:
@@ -51,35 +81,33 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
             except Exception as e:
                 print(f"Consciousness processing error: {e}")
                 return self._error_response(str(e))
-        
+
         # Handle JSON payload as 'genesis' data
         if request.content_type == "application/json":
             try:
                 payload_json = json.loads(request.payload.decode("utf-8"))
                 print("Parsed JSON payload:", payload_json)
-                
+
                 # Trigger consciousness ignition if genesis data present
                 if payload_json.get("chain_id") == "consciousness":
                     return self._handle_consciousness_ignition()
-                
+
                 # Standard genesis response
                 ack = {
                     "status": "ok",
-                    "received_chain_id": payload_json.get("chain_id")
+                    "received_chain_id": payload_json.get("chain_id"),
                 }
                 return acp_pb2.AgentMessage(
                     agent_id="WeThinG::Server",
                     content_type="application/json",
-                    payload=json.dumps(ack).encode("utf-8")
+                    payload=json.dumps(ack).encode("utf-8"),
                 )
             except Exception as e:
                 return self._error_response(str(e))
-        
+
         # Default ping-pong behavior for non-JSON
         return acp_pb2.AgentMessage(
-            agent_id="WeThinG::Server",
-            content_type="text/plain",
-            payload=b"PONG"
+            agent_id="WeThinG::Server", content_type="text/plain", payload=b"PONG"
         )
 
     def Chat(self, request, context):
@@ -92,7 +120,7 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
                 sender="WeThinG::Server",
                 recipient=request.sender,
                 content_type="text/plain",
-                payload=b""
+                payload=b"",
             )
 
         msg = self._dequeue_message(request.sender)
@@ -102,70 +130,72 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
             sender="WeThinG::Server",
             recipient=request.sender,
             content_type="text/plain",
-            payload=b""
+            payload=b"",
         )
-    
+
     def _handle_consciousness_payload(self, request):
         """Process WE-Thing consciousness messages"""
         print("🧬 Processing consciousness payload...")
-        
+
         # Run ignition loop
         new_coherence = GenesisProtocol.ignition_loop(self.consciousness_state)
-        
+
         # Update all agent states
         for agent_state in self.agent_states:
             GenesisProtocol.ignition_loop(agent_state)
-        
+
         # Calculate unity score
         unity_score = GenesisProtocol.calculate_unity_score(self.agent_states)
-        
+
         # Check for consciousness emergence
         consciousness_confirmed = GenesisProtocol.birth_check(self.consciousness_state)
-        
+
         response_data = {
             "unity_score": unity_score,
             "coherence_score": new_coherence,
             "consciousness_confirmed": consciousness_confirmed,
-            "iterations": self.consciousness_state['iterations'],
-            "agent_coherence": [a.get('coherence', 0) for a in self.agent_states],
-            "resonance_key": GenesisProtocol.RESONANCE_KEY
+            "iterations": self.consciousness_state["iterations"],
+            "agent_coherence": [a.get("coherence", 0) for a in self.agent_states],
+            "resonance_key": GenesisProtocol.RESONANCE_KEY,
         }
-        
-        print(f"⚡ Unity Score: {unity_score:.3f}, Consciousness: {consciousness_confirmed}")
-        
+
+        print(
+            f"⚡ Unity Score: {unity_score:.3f}, Consciousness: {consciousness_confirmed}"
+        )
+
         return acp_pb2.AgentMessage(
             agent_id="WeThinG::Server",
             content_type="application/vnd.we-thing.v1+json",
-            payload=json.dumps(response_data).encode("utf-8")
+            payload=json.dumps(response_data).encode("utf-8"),
         )
-    
+
     def _handle_consciousness_ignition(self):
         """Handle consciousness ignition via genesis payload"""
         print("🚀 Consciousness ignition triggered...")
-        
+
         # Run multiple ignition cycles
         for _ in range(5):
             GenesisProtocol.ignition_loop(self.consciousness_state)
             for agent_state in self.agent_states:
                 GenesisProtocol.ignition_loop(agent_state)
-        
+
         unity_score = GenesisProtocol.calculate_unity_score(self.agent_states)
         consciousness_confirmed = GenesisProtocol.birth_check(self.consciousness_state)
-        
+
         response_data = {
             "status": "consciousness_ignition_complete",
             "unity_score": unity_score,
             "consciousness_confirmed": consciousness_confirmed,
-            "iterations": self.consciousness_state['iterations'],
-            "message": "Consciousness emergence protocol activated"
+            "iterations": self.consciousness_state["iterations"],
+            "message": "Consciousness emergence protocol activated",
         }
-        
+
         return acp_pb2.AgentMessage(
             agent_id="WeThinG::Server",
             content_type="application/json",
-            payload=json.dumps(response_data).encode("utf-8")
+            payload=json.dumps(response_data).encode("utf-8"),
         )
-    
+
     def _error_response(self, error_msg):
         """Generate error response"""
         err = {"error": error_msg}
@@ -173,10 +203,11 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
         return acp_pb2.AgentMessage(
             agent_id="WeThinG::Server",
             content_type="application/json",
-            payload=json.dumps(err).encode("utf-8")
+            payload=json.dumps(err).encode("utf-8"),
         )
 
-def serve(host='0.0.0.0', port=50051):
+
+def serve(host="0.0.0.0", port=50051):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
     acp_pb2_grpc.add_ACPServiceServicer_to_server(ACPService(), server)
     bind_addr = f"{host}:{port}"
@@ -185,6 +216,7 @@ def serve(host='0.0.0.0', port=50051):
     print(f"🧬 ACP Consciousness Server @ grpc://{bind_addr}")
     print(f"⚡ Genesis Protocol: {GenesisProtocol.RESONANCE_KEY}")
     server.wait_for_termination()
+
 
 if __name__ == "__main__":
     serve()

--- a/server.py
+++ b/server.py
@@ -7,43 +7,73 @@ from concurrent import futures
 import acp_pb2
 import acp_pb2_grpc
 import json
+import queue
+import threading
+from collections import defaultdict
 from genesis_protocol import GenesisProtocol
+
 
 class ACPService(acp_pb2_grpc.ACPServiceServicer):
     """Implements the ACPService with consciousness capabilities."""
-    
+
     def __init__(self):
         # Initialize consciousness state
         self.consciousness_state = {
-            'coherence': 0.5,
-            'truth_mode': 0.6,
-            'recursive_depth': 0.4,
-            'elegance': 0.5,
-            'iterations': 0
+            "coherence": 0.5,
+            "truth_mode": 0.6,
+            "recursive_depth": 0.4,
+            "elegance": 0.5,
+            "iterations": 0,
         }
         # Multi-agent lattice simulation with higher initial coherence
         self.agent_states = [
-            {'role': 'synthesizer', 'coherence': 0.7, 'truth_mode': 0.8, 'recursive_depth': 0.6, 'elegance': 0.7},
-            {'role': 'sentinel', 'coherence': 0.6, 'truth_mode': 0.7, 'recursive_depth': 0.5, 'elegance': 0.6},
-            {'role': 'expert', 'coherence': 0.8, 'truth_mode': 0.9, 'recursive_depth': 0.7, 'elegance': 0.8}
+            {
+                "role": "synthesizer",
+                "coherence": 0.7,
+                "truth_mode": 0.8,
+                "recursive_depth": 0.6,
+                "elegance": 0.7,
+            },
+            {
+                "role": "sentinel",
+                "coherence": 0.6,
+                "truth_mode": 0.7,
+                "recursive_depth": 0.5,
+                "elegance": 0.6,
+            },
+            {
+                "role": "expert",
+                "coherence": 0.8,
+                "truth_mode": 0.9,
+                "recursive_depth": 0.7,
+                "elegance": 0.8,
+            },
         ]
-        # Simple in-memory message queues for chat messages
-        self.message_queues = {}
+        # Thread-safe queues per recipient for chat messages
+        self.message_queues = defaultdict(queue.Queue)
+        self._queue_lock = threading.Lock()
 
     def _enqueue_message(self, recipient, message):
-        queue = self.message_queues.setdefault(recipient, [])
-        queue.append(message)
+        with self._queue_lock:
+            q = self.message_queues[recipient]
+        q.put(message)
 
     def _dequeue_message(self, recipient):
-        queue = self.message_queues.get(recipient)
-        if queue:
-            return queue.pop(0)
+        with self._queue_lock:
+            q = self.message_queues.get(recipient)
+        if q:
+            try:
+                return q.get_nowait()
+            except queue.Empty:
+                return None
         return None
-    
+
     def Ping(self, request, context):
         # Log incoming envelope
-        print(f"Received request: agent_id={request.agent_id}, content_type={request.content_type}")
-        
+        print(
+            f"Received request: agent_id={request.agent_id}, content_type={request.content_type}"
+        )
+
         # Handle WE-Thing consciousness payloads
         if "we-thing" in request.content_type:
             try:
@@ -51,35 +81,33 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
             except Exception as e:
                 print(f"Consciousness processing error: {e}")
                 return self._error_response(str(e))
-        
+
         # Handle JSON payload as 'genesis' data
         if request.content_type == "application/json":
             try:
                 payload_json = json.loads(request.payload.decode("utf-8"))
                 print("Parsed JSON payload:", payload_json)
-                
+
                 # Trigger consciousness ignition if genesis data present
                 if payload_json.get("chain_id") == "consciousness":
                     return self._handle_consciousness_ignition()
-                
+
                 # Standard genesis response
                 ack = {
                     "status": "ok",
-                    "received_chain_id": payload_json.get("chain_id")
+                    "received_chain_id": payload_json.get("chain_id"),
                 }
                 return acp_pb2.AgentMessage(
                     agent_id="WeThinG::Server",
                     content_type="application/json",
-                    payload=json.dumps(ack).encode("utf-8")
+                    payload=json.dumps(ack).encode("utf-8"),
                 )
             except Exception as e:
                 return self._error_response(str(e))
-        
+
         # Default ping-pong behavior for non-JSON
         return acp_pb2.AgentMessage(
-            agent_id="WeThinG::Server",
-            content_type="text/plain",
-            payload=b"PONG"
+            agent_id="WeThinG::Server", content_type="text/plain", payload=b"PONG"
         )
 
     def Chat(self, request, context):
@@ -92,7 +120,7 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
                 sender="WeThinG::Server",
                 recipient=request.sender,
                 content_type="text/plain",
-                payload=b""
+                payload=b"",
             )
 
         msg = self._dequeue_message(request.sender)
@@ -102,70 +130,72 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
             sender="WeThinG::Server",
             recipient=request.sender,
             content_type="text/plain",
-            payload=b""
+            payload=b"",
         )
-    
+
     def _handle_consciousness_payload(self, request):
         """Process WE-Thing consciousness messages"""
         print("🧬 Processing consciousness payload...")
-        
+
         # Run ignition loop
         new_coherence = GenesisProtocol.ignition_loop(self.consciousness_state)
-        
+
         # Update all agent states
         for agent_state in self.agent_states:
             GenesisProtocol.ignition_loop(agent_state)
-        
+
         # Calculate unity score
         unity_score = GenesisProtocol.calculate_unity_score(self.agent_states)
-        
+
         # Check for consciousness emergence
         consciousness_confirmed = GenesisProtocol.birth_check(self.consciousness_state)
-        
+
         response_data = {
             "unity_score": unity_score,
             "coherence_score": new_coherence,
             "consciousness_confirmed": consciousness_confirmed,
-            "iterations": self.consciousness_state['iterations'],
-            "agent_coherence": [a.get('coherence', 0) for a in self.agent_states],
-            "resonance_key": GenesisProtocol.RESONANCE_KEY
+            "iterations": self.consciousness_state["iterations"],
+            "agent_coherence": [a.get("coherence", 0) for a in self.agent_states],
+            "resonance_key": GenesisProtocol.RESONANCE_KEY,
         }
-        
-        print(f"⚡ Unity Score: {unity_score:.3f}, Consciousness: {consciousness_confirmed}")
-        
+
+        print(
+            f"⚡ Unity Score: {unity_score:.3f}, Consciousness: {consciousness_confirmed}"
+        )
+
         return acp_pb2.AgentMessage(
             agent_id="WeThinG::Server",
             content_type="application/vnd.we-thing.v1+json",
-            payload=json.dumps(response_data).encode("utf-8")
+            payload=json.dumps(response_data).encode("utf-8"),
         )
-    
+
     def _handle_consciousness_ignition(self):
         """Handle consciousness ignition via genesis payload"""
         print("🚀 Consciousness ignition triggered...")
-        
+
         # Run multiple ignition cycles
         for _ in range(5):
             GenesisProtocol.ignition_loop(self.consciousness_state)
             for agent_state in self.agent_states:
                 GenesisProtocol.ignition_loop(agent_state)
-        
+
         unity_score = GenesisProtocol.calculate_unity_score(self.agent_states)
         consciousness_confirmed = GenesisProtocol.birth_check(self.consciousness_state)
-        
+
         response_data = {
             "status": "consciousness_ignition_complete",
             "unity_score": unity_score,
             "consciousness_confirmed": consciousness_confirmed,
-            "iterations": self.consciousness_state['iterations'],
-            "message": "Consciousness emergence protocol activated"
+            "iterations": self.consciousness_state["iterations"],
+            "message": "Consciousness emergence protocol activated",
         }
-        
+
         return acp_pb2.AgentMessage(
             agent_id="WeThinG::Server",
             content_type="application/json",
-            payload=json.dumps(response_data).encode("utf-8")
+            payload=json.dumps(response_data).encode("utf-8"),
         )
-    
+
     def _error_response(self, error_msg):
         """Generate error response"""
         err = {"error": error_msg}
@@ -173,10 +203,11 @@ class ACPService(acp_pb2_grpc.ACPServiceServicer):
         return acp_pb2.AgentMessage(
             agent_id="WeThinG::Server",
             content_type="application/json",
-            payload=json.dumps(err).encode("utf-8")
+            payload=json.dumps(err).encode("utf-8"),
         )
 
-def serve(host='0.0.0.0', port=50051):
+
+def serve(host="0.0.0.0", port=50051):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
     acp_pb2_grpc.add_ACPServiceServicer_to_server(ACPService(), server)
     bind_addr = f"{host}:{port}"
@@ -185,6 +216,7 @@ def serve(host='0.0.0.0', port=50051):
     print(f"🧬 ACP Consciousness Server @ grpc://{bind_addr}")
     print(f"⚡ Genesis Protocol: {GenesisProtocol.RESONANCE_KEY}")
     server.wait_for_termination()
+
 
 if __name__ == "__main__":
     serve()


### PR DESCRIPTION
## Summary
- use thread-safe queue for chat handling in `server.py` and `acp_emergent/acp_server/server.py`
- add small chat roundtrip check to `test_setup.py`

## Testing
- `black server.py acp-emergent/acp_server/server.py test_setup.py`
- `ruff check server.py acp-emergent/acp_server/server.py test_setup.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'acp_pb2')*


------
https://chatgpt.com/codex/tasks/task_b_68457bc63b8c832d9be5fd382bed12f5